### PR TITLE
Use dateutil for parsing datetime strings

### DIFF
--- a/azure_iot_hub_api/models.py
+++ b/azure_iot_hub_api/models.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from dateutil import parser as datetime_parser
 
 
 class Device:
@@ -42,13 +43,13 @@ class Device:
         connection_state = device_dictionary.get("connectionState")
         status = device_dictionary.get("status")
         status_reason = device_dictionary.get("statusReason")
-        connection_state_updated_time = datetime.fromisoformat(
+        connection_state_updated_time = datetime_parser.parse(
             device_dictionary.get('connectionStateUpdatedTime') or "0001-01-01T00:00:00.000-00:00"
         )
-        status_updated_time = datetime.fromisoformat(
+        status_updated_time = datetime_parser.parse(
             device_dictionary.get("statusUpdatedTime") or "0001-01-01T00:00:00.000-00:00"
             )
-        last_activity_time = datetime.fromisoformat(
+        last_activity_time = datetime_parser.parse(
             device_dictionary.get('lastActivityTime') or "0001-01-01T00:00:00.000-00:00"
             )
         cloud_to_device_message_count = device_dictionary.get("cloudToDeviceMessageCount")
@@ -164,9 +165,9 @@ class Twin:
         device_etag = twin_dictionary.get("deviceEtag")
         status = twin_dictionary.get("status")
         status_reason = twin_dictionary.get("statusReason")
-        status_update_time = datetime.fromisoformat(twin_dictionary.get("statusUpdateTime"))
+        status_update_time = datetime_parser.parse(twin_dictionary.get("statusUpdateTime"))
         connection_state = twin_dictionary.get("connectionState")
-        last_activity_time = datetime.fromisoformat(twin_dictionary.get("lastActivityTime"))
+        last_activity_time = datetime_parser.parse(twin_dictionary.get("lastActivityTime"))
         cloud_to_device_message_count = twin_dictionary.get("cloudToDeviceMessageCount")
         authentication_type = twin_dictionary.get("authenticationType")
         x509_thumbprint = twin_dictionary.get("x509Thumbprint")

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ setup_args = dict(
 )
 
 install_requires = [
-    'azure-cli[azure-iot]'
+    'azure-cli'
 ]
 
 if __name__ == '__main__':
-	setup(**setup_args, install_requires=install_requires)
+    setup(**setup_args, install_requires=install_requires)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as readme_file:
 
 setup_args = dict(
     name='azure-iot-hub-api',
-    version='0.2.0',
+    version='0.2.1',
     description='Azure iot hub api with azure cli backend',
     long_description_content_type="text/markdown",
     long_description=README,
@@ -20,8 +20,8 @@ setup_args = dict(
 )
 
 install_requires = [
-    'azure-cli',
-    'python-dateutil'
+    'azure-cli==2.71.0',
+    'python-dateutil~=2.9'
 ]
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setup_args = dict(
 )
 
 install_requires = [
-    'azure-cli'
+    'azure-cli',
+    'python-dateutil'
 ]
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hey there, thanks a lot for the nice tool! I've noticed there is a minor thing with datetime parsing that can be improved. The current implementation throws the following error:
```
Traceback (most recent call last):
  File "/myproject/venv/lib/python3.10/site-packages/IPython/core/interactiveshell.py", line 3550, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-5-0cf0aa12b443>", line 1, in <module>
    twin = manager.get_twin("my_device")
  File "/myproject/venv/lib/python3.10/site-packages/azure_iot_hub_api/azure_iot_hub.py", line 34, in get_twin
    return Twin.from_dictionary(result)
  File "/myproject/venv/lib/python3.10/site-packages/azure_iot_hub_api/models.py", line 167, in from_dictionary
    status_update_time = datetime.fromisoformat(twin_dictionary.get("statusUpdateTime"))
ValueError: Invalid isoformat string: '2025-01-27T16:35:04.6698773Z'
```
This pull request should fix this.